### PR TITLE
feat: export rules and plugins separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,36 @@ Opinionated ESLint config used by Auk's React projects
 
 Install eslint-config-auk:
 
-Using NPM:
-
 ```
 npm install --save-dev eslint-config-auk
 ```
 
-With Yarn:
+Then, add it to your `eslint.config.mjs`:
 
-```
-yarn add -D eslint-config-auk
+```js
+import auk from 'eslint-config-auk'
+
+export default [
+	...auk
+	// your overrides
+]
 ```
 
-Then, add eslint-config-auk to the "extends" array in your ESLint file (`.eslintrc` or `.eslintrc.js`). Make sure to put
-it last if you want to override other configs.
+### Using with other shared configs (e.g. Next.js)
 
-```json
-{
-	"extends": ["auk"]
-}
+If you already have a shared config that registers overlapping plugins (like `eslint-config-next`), import just the
+rules to avoid "Cannot redefine plugin" errors:
+
+```js
+import { rules as aukRules } from 'eslint-config-auk'
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+
+export default [
+	...nextCoreWebVitals,
+	aukRules
+	// your overrides
+]
 ```
+
+The `rules` export contains all of auk's rule configuration and settings without any plugin registrations, so it
+composes cleanly with any config that already provides those plugins.

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const baseConfigs = [
 ]
 
 /** @type {import('eslint').Linter.Config} */
-const config = {
+const rules = {
 	files: ['**/*.{js,mjs,cjs,jsx,mjsx,ts,tsx,mtsx}'],
 	languageOptions: {
 		ecmaVersion: 'latest',
@@ -41,10 +41,6 @@ const config = {
 		react: {
 			version: 'detect'
 		}
-	},
-	plugins: {
-		// @ts-expect-error react-hooks is out of date, see
-		'react-hooks': reactHooks
 	},
 	rules: {
 		'@typescript-eslint/array-type': [enabled, { default: 'array-simple' }],
@@ -123,4 +119,49 @@ const config = {
 	}
 }
 
-export default [...baseConfigs, config]
+/**
+ * Plugins unique to auk that aren't commonly provided by other shared configs.
+ * Use alongside `rules` when another config (e.g. eslint-config-next) already
+ * registers the common plugins (@typescript-eslint, react, import, jsx-a11y, etc).
+ *
+ * Registers: github, i18n-text, eslint-comments, no-only-tests, escompat
+ */
+const commonPlugins = new Set([
+	'@typescript-eslint',
+	'import',
+	'importPlugin',
+	'jsx-a11y',
+	'jsxA11yPlugin',
+	'react',
+	'react-hooks',
+	'prettierPlugin'
+])
+
+function extractUniquePlugins() {
+	const githubConfigs = [
+		github.getFlatConfigs().recommended,
+		github.getFlatConfigs().react,
+		...github.getFlatConfigs().typescript
+	]
+
+	const result = []
+	for (const config of githubConfigs) {
+		if (!config?.plugins) continue
+		const filtered = {}
+		for (const [name, plugin] of Object.entries(config.plugins)) {
+			if (!commonPlugins.has(name)) {
+				filtered[name] = plugin
+			}
+		}
+		if (Object.keys(filtered).length > 0) {
+			result.push({ plugins: filtered })
+		}
+	}
+	return result
+}
+
+export const plugins = extractUniquePlugins()
+
+export { rules }
+
+export default [...baseConfigs, rules]

--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
+  },
+  "exports": {
+    ".": "./index.js",
+    "./rules": "./index.js"
   }
 }


### PR DESCRIPTION
## Summary

- Adds named `rules` and `plugins` exports for composability with other shared configs
- When used alongside configs like `eslint-config-next` that register overlapping plugins, consumers can import just the rules + auk-unique plugins to avoid ESLint's "Cannot redefine plugin" error
- Default export unchanged — no breaking change

### Usage with other shared configs

```js
import { plugins as aukPlugins, rules as aukRules } from 'eslint-config-auk';
import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';

export default [
  ...nextCoreWebVitals,
  ...aukPlugins,
  aukRules,
];
```

- Updates README to document flat config usage and the new exports